### PR TITLE
Add create_spf_record flag to make SPF record optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,33 @@ module "verification" {
 
   domain = "example.com"
   zone_id = "<your Cloudflare zone ID>"
+
+  # Optional: only set to true if you do NOT already have an SPF record
+  create_spf_record = false
 }
 ```
 
 ## Requirements
 
-| Name | Version |
-| ---  | ---     |
+| Name                | Version            |
+| ------------------- | ------------------ |
 | Terraform           | `>=1.9.5, <2.0.0`  |
 | Cloudflare provider | `>=4.40.0, <5.0.0` |
 | AWS provider        | `>=5.64.0, <6.0.0` |
 
 ## Providers
 
-| Name | Version |
-| ---  | ---     |
+| Name                | Version            |
+| ------------------- | ------------------ |
 | Cloudflare provider | `>=4.40.0, <5.0.0` |
 | AWS provider        | `>=5.64.0, <6.0.0` |
 
-
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| `domain`  | FQDN for the domain you want to create the SES verification for. | `string` | n/a | yes |
-| `zone_id` | Cloudflare Zone ID                                               | `string` | n/a | yes |
+| Name      | Description                                                      | Type     | Default | Required |
+| --------- | ---------------------------------------------------------------- | -------- | ------- | :------: |
+| `domain`  | FQDN for the domain you want to create the SES verification for. | `string` | n/a     |   yes    |
+| `zone_id` | Cloudflare Zone ID                                               | `string` | n/a     |   yes    |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "cloudflare_record" "dkim" {
 }
 
 resource "cloudflare_record" "spf" {
+  count   = var.create_spf_record ? 1 : 0
   zone_id = var.zone_id
   name    = var.domain
   type    = "TXT"

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,8 @@ variable "domain" {
   description = "FQDN for the domain you want to create the SES verification for."
 }
 
+variable "create_spf_record" {
+  type        = bool
+  default     = false
+  description = "Create an SPF record for the domain."
+}


### PR DESCRIPTION
Gave the module the option to not create the SPF record. This would be used when you already have a SPF module in your DNS that you manually take care of.