### PR TITLE
Wrap spf record in double inverted commas as per doco 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ module "verification" {
 
   # Optional: only set to true if you do NOT already have an SPF record. This option defaults to true if ommitted.
   create_spf_record = true
+
+  # Optional: Add a comment to your SPF record
+  spf_comment  = "SPF record for sending emails via Amazon SES"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -35,5 +35,5 @@ resource "cloudflare_record" "spf" {
   zone_id = var.zone_id
   name    = var.domain
   type    = "TXT"
-  content = "v=spf1 include:amazonses.com -all"
+  content = "\"v=spf1 include:amazonses.com -all\""
 }

--- a/main.tf
+++ b/main.tf
@@ -36,4 +36,5 @@ resource "cloudflare_record" "spf" {
   name    = var.domain
   type    = "TXT"
   content = "\"v=spf1 include:amazonses.com -all\""
+  comment = var.spf_comment
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "create_spf_record" {
   default     = true
   description = "Create an SPF record for the domain."
 }
+
+variable "spf_comment" {
+  type        = string
+  description = "Optional comment to add to the SPF DNS record"
+  default     = null
+}


### PR DESCRIPTION
SPF records need to be added to Cloudflare between inverted commas.

Doco - https://www.cloudflare.com/learning/dns/dns-records/dns-txt-record/

Current results look like this...

![image](https://github.com/user-attachments/assets/cd421cd2-974b-48c3-b1ce-373874966e2f)

After the fix It should look like this...

![image](https://github.com/user-attachments/assets/4bc36d4b-b0db-4976-9d2d-24f7f4747706)


