### PR TITLE
Relax AWS provider constraint to allow >= 5.64.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">=4.40.0, <5.0.0"
+      version = ">=4.40.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
The constraint < 6.0.0 is overly restrictive, the newer versions of the AWS provider (v6+) should be allowed.

Getting the following error when trying to run `terragrunt init` constraints can't be `>= 6.0.0, < 6.0.0`


```bash

14:47:00.620 STDERR terraform: ╷
14:47:00.620 STDERR terraform: │ Error: Failed to query available provider packages
14:47:00.620 STDERR terraform: │ 
14:47:00.620 STDERR terraform: │ Could not retrieve the list of available versions for provider
14:47:00.621 STDERR terraform: │ hashicorp/aws: no available releases match the given constraints >= 3.29.0,
14:47:00.621 STDERR terraform: │ >= 4.66.1, >= 5.64.0, ~> 5.73.0, >= 5.85.0, >= 5.93.0, >= 5.99.0, >= 6.0.0,
14:47:00.621 STDERR terraform: │ < 6.0.0
14:47:00.621 STDERR terraform: │ 
14:47:00.621 STDERR terraform: │ To see which modules are currently depending on hashicorp/aws and what
14:47:00.621 STDERR terraform: │ versions are specified, run the following command:
14:47:00.621 STDERR terraform: │     terraform providers

```