### PR TITLE
Relaxed provider constraints for hashicorp/aws v6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,26 @@ module "verification" {
 
 ## Requirements
 
-| Name                | Version            |
-| ------------------- | ------------------ |
-| Terraform           | `>=1.9.5, <2.0.0`  |
-| Cloudflare provider | `>=4.40.0, <5.0.0` |
-| AWS provider        | `>=5.64.0, <6.0.0` |
+| Name                | Version           |
+| ------------------- | ----------------- |
+| Terraform           | `>=1.9.5, <2.0.0` |
+| Cloudflare provider | `>=4.40.0`        |
+| AWS provider        | `>=5.64.0`        |
 
 ## Providers
 
-| Name                | Version            |
-| ------------------- | ------------------ |
-| Cloudflare provider | `>=4.40.0, <5.0.0` |
-| AWS provider        | `>=5.64.0, <6.0.0` |
+| Name                | Version    |
+| ------------------- | ---------- |
+| Cloudflare provider | `>=4.40.0` |
+| AWS provider        | `>=5.64.0` |
 
 ## Inputs
 
-| Name      | Description                                                      | Type     | Default | Required |
-| --------- | ---------------------------------------------------------------- | -------- | ------- | :------: |
-| `domain`  | FQDN for the domain you want to create the SES verification for. | `string` | n/a     |   yes    |
-| `zone_id` | Cloudflare Zone ID                                               | `string` | n/a     |   yes    |
+| Name                | Description                                                      | Type     | Default | Required |
+| ------------------- | ---------------------------------------------------------------- | -------- | ------- | :------: |
+| `domain`            | FQDN for the domain you want to create the SES verification for. | `string` | n/a     |   yes    |
+| `zone_id`           | Cloudflare Zone ID                                               | `string` | n/a     |   yes    |
+| `create_spf_record` | Add an spf record                                                | `bool`   | true    |    no    |
 
 ## Outputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">=4.40.0, <5.0.0"
+      version = ">=4.40.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.64.0, <6.0.0"
+      version = ">=5.64.0"
     }
   }
 }


### PR DESCRIPTION
The constraint < 6.0.0 is overly restrictive, the newer versions of the AWS provider (v6+) should be allowed.

Getting the following error when trying to run `terragrunt init` constraints can't be `>= 6.0.0, < 6.0.0`


```bash

14:47:00.620 STDERR terraform: ╷
14:47:00.620 STDERR terraform: │ Error: Failed to query available provider packages
14:47:00.620 STDERR terraform: │ 
14:47:00.620 STDERR terraform: │ Could not retrieve the list of available versions for provider
14:47:00.621 STDERR terraform: │ hashicorp/aws: no available releases match the given constraints >= 3.29.0,
14:47:00.621 STDERR terraform: │ >= 4.66.1, >= 5.64.0, ~> 5.73.0, >= 5.85.0, >= 5.93.0, >= 5.99.0, >= 6.0.0,
14:47:00.621 STDERR terraform: │ < 6.0.0
14:47:00.621 STDERR terraform: │ 
14:47:00.621 STDERR terraform: │ To see which modules are currently depending on hashicorp/aws and what
14:47:00.621 STDERR terraform: │ versions are specified, run the following command:
14:47:00.621 STDERR terraform: │     terraform providers

```

I also updated the Readme.